### PR TITLE
Pin lt-codes to AplinkosMinisterija fork v1.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "formik": "^2.2.9",
     "leaflet": "^1.9.3",
     "lodash": "^4.17.21",
-    "lt-codes": "ambrazasp/lt-codes",
+    "lt-codes": "github:AplinkosMinisterija/lt-codes#v1.1.2",
     "react": "^18.2.0",
     "react-datepicker": "^4.11.0",
     "react-div-100vh": "^0.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6352,9 +6352,9 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
-lt-codes@ambrazasp/lt-codes:
-  version "1.0.3"
-  resolved "https://codeload.github.com/ambrazasp/lt-codes/tar.gz/9fbf85b126e9fd687afe34af7c99e0e951186c37"
+"lt-codes@github:AplinkosMinisterija/lt-codes#v1.1.2":
+  version "1.1.2"
+  resolved "https://codeload.github.com/AplinkosMinisterija/lt-codes/tar.gz/9938111ffa8212cfccda00938c5a502cd7f4bc97"
   dependencies:
     moment "^2.29.4"
 


### PR DESCRIPTION
## Kontekstas

Sinchronizacija prie AM-kontroliuojamo \`lt-codes\` lib'o. Repas naudoja tik \`personalCode.validate\` (\`src/utils/validations.ts\`), tad FA_ \`companyCode\` palaikymo praplėtimas funkcinio efekto čia neturi — tikslas yra suvienodinti šaltinį visose AM repo'se.

## Pakeitimai

\`package.json\`:
- \`"lt-codes": "ambrazasp/lt-codes"\` → \`"lt-codes": "github:AplinkosMinisterija/lt-codes#v1.1.2"\`

\`yarn.lock\` atnaujintas. Kodo pakeitimų nėra.

## Susiję PR'ai

- Fork: AplinkosMinisterija/lt-codes#3, #5
- Release: https://github.com/AplinkosMinisterija/lt-codes/releases/tag/v1.1.2

## Test plan

- [ ] \`yarn install\` — \`node_modules/lt-codes/dist/index.js\` egzistuoja.
- [ ] \`yarn build\` praeina.
- [ ] Asmens kodo validacija formoje veikia kaip iki šiol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)